### PR TITLE
Bump font awesome core version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2984,14 +2984,24 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001235",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
-            "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
+            "version": "1.0.30001629",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+            "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
             "dev": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/browserslist"
-            }
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ]
         },
         "node_modules/chalk": {
             "version": "2.4.2",
@@ -16662,9 +16672,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001235",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001235.tgz",
-            "integrity": "sha512-zWEwIVqnzPkSAXOUlQnPW2oKoYb2aLQ4Q5ejdjBcnH63rfypaW34CxaeBn1VMya2XaEU3P/R2qHpWyj+l0BT1A==",
+            "version": "1.0.30001629",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001629.tgz",
+            "integrity": "sha512-c3dl911slnQhmxUIT4HhYzT7wnBK/XYpGnYLOj4nJBaRiw52Ibe7YxlDaAeRECvA786zCuExhxIUJ2K7nHMrBw==",
             "dev": true
         },
         "chalk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.2",
             "license": "MIT",
             "dependencies": {
-                "@fortawesome/fontawesome-svg-core": "^1.2.35"
+                "@fortawesome/fontawesome-svg-core": "^6.5.2"
             },
             "devDependencies": {
                 "@babel/cli": "^7.12.1",
@@ -658,21 +658,21 @@
             }
         },
         "node_modules/@fortawesome/fontawesome-common-types": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-            "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw==",
             "hasInstallScript": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@fortawesome/fontawesome-svg-core": {
-            "version": "1.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-            "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
             "hasInstallScript": true,
             "dependencies": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "6.5.2"
             },
             "engines": {
                 "node": ">=6"
@@ -14915,16 +14915,16 @@
             }
         },
         "@fortawesome/fontawesome-common-types": {
-            "version": "0.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-            "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.2.tgz",
+            "integrity": "sha512-gBxPg3aVO6J0kpfHNILc+NMhXnqHumFxOmjYCFfOiLZfwhnnfhtsdA2hfJlDnj+8PjAs6kKQPenOTKj3Rf7zHw=="
         },
         "@fortawesome/fontawesome-svg-core": {
-            "version": "1.2.35",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-            "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.2.tgz",
+            "integrity": "sha512-5CdaCBGl8Rh9ohNdxeeTMxIj8oc3KNBgIeLMvJosBMdslK/UnEB8rzyDRrbKdL1kDweqBPo4GT9wvnakHWucZw==",
             "requires": {
-                "@fortawesome/fontawesome-common-types": "^0.2.35"
+                "@fortawesome/fontawesome-common-types": "6.5.2"
             }
         },
         "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
         "watch": "^0.13.0"
     },
     "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.35"
+        "@fortawesome/fontawesome-svg-core": "^6.5.2"
     }
 }


### PR DESCRIPTION
Bumped caniuse and font-awesome core dependencies.

The jump to 6.5.2 might seem a bit excessive, but it's only a few versions as the went from 1.2.36 directly to 6.1.0, ignoring the beta releases in between.