### PR TITLE
chore/bump node version ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test:  
     # A list of available CircleCI Docker Convenience Images are available here: https://circleci.com/developer/images/image/cimg/node
     docker:
-      - image: cimg/node:15.1
+      - image: cimg/node:18.16
     # Then run your tests!
     # CircleCI will report the results back to your VCS provider.
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@vidhill/fortawesome-11ty-shortcode-helper",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@vidhill/fortawesome-11ty-shortcode-helper",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "license": "MIT",
             "dependencies": {
                 "@fortawesome/fontawesome-svg-core": "^6.5.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vidhill/fortawesome-11ty-shortcode-helper",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "description": "Helper utilities for creating a fortawesome eleventy shortcode",
     "main": "build/index.js",
     "scripts": {


### PR DESCRIPTION
- **1.1.0**
- **Bump version of node docker image on circle-ci**
